### PR TITLE
Add script to check links

### DIFF
--- a/hack/markdown-link-check.json
+++ b/hack/markdown-link-check.json
@@ -1,0 +1,8 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^(?!(https?://(pingcap.com|github.com|tikv.org)/|media/))"
+        }
+    ],
+    "replacementPatterns": []
+}

--- a/hack/verify-links.sh
+++ b/hack/verify-links.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# This script is used to verify links in markdown docs.
+#
+
+ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+cd $ROOT
+
+if ! which markdown-link-check &>/dev/null; then
+    sudo npm install -g markdown-link-check@3.7.3
+fi
+
+#
+# Currently, we only check pingcap.com/github.com/tikv.org links and media
+# static files. This is because external websites are beyond our control.
+#
+# TODO check more links
+#
+CONFIG_TMP=hack/markdown-link-check.json
+ERROR_REPORT=$(mktemp)
+
+trap 'rm -f $ERROR_REPORT' EXIT
+
+while read -r tasks; do
+    for task in $tasks; do
+        (
+            echo markdown-link-check --config "$CONFIG_TMP" "$task" -q
+            output=$(markdown-link-check --color --config "$CONFIG_TMP" "$task" -q)
+            if [ $? -ne 0 ]; then
+                printf "$output" >> $ERROR_REPORT
+            fi
+            echo "$output"
+        ) &
+    done
+    wait
+done <<<"$(find . -mindepth 1 -maxdepth 1 -type f -name '*.md' -print0 | xargs -0 -n 30)"
+
+error_files=$(cat $ERROR_REPORT | grep 'FILE: ' | wc -l)
+error_output=$(cat $ERROR_REPORT)
+
+echo ""
+if [ "$error_files" -gt 0 ]; then
+    echo "error: $error_files files have invalid links, please fix them!"
+    echo ""
+    echo "=== ERROR REPORT == ":
+    echo "$error_output"
+    exit 1
+else
+    echo "info: all files are ok!"
+fi


### PR DESCRIPTION
Help us to fix broken links. Currently, it only checks pingcap.com/github.com/tikv.org links and media static files.

**Update:** This script can run in CI (e.g. circle ci).

Current broken links:

```
FILE: ./percona-live-austin-summary-and-reflection.md
[✖] media/samantha-peters-running-a-raffle-for-conference-attendees.png
FILE: ./tidb-2.1-ga-Battle-tested-to-handle-an-unpredictable-world.md
[✖] https://pingcap.com/docs/tools/tidb-binlog-cluster/
FILE: ./adding-built-in-functions-to-tikv.md
[✖] https://github.com/pingcap/tikv/blob/master/src/coprocessor/dag/expr/scalar_function.rs
[✖] https://github.com/pingcap/tikv/blob/master/src/coprocessor/dag/expr/builtin_arithmetic.rs
```

It's better to use [github permanent links](https://help.github.com/en/articles/getting-permanent-links-to-files) in blog articles.