### PR TITLE
.github: add a workflow for scheduled pr merge

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -1,0 +1,24 @@
+name: Merge Schedule
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  schedule:
+    # every day at 8:00 UTC/1:00 PDT/16:00 BJT
+    - cron: 0 8 * * *
+
+jobs:
+  merge_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/merge-schedule-action@v1
+        with:
+          # Merge method to use. Possible values are merge, squash or
+          # rebase. Default is merge.
+          merge_method: squash
+          #  Time zone to use. Default is UTC.
+          time_zone: "America/Los_Angeles"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Ran <huangran@pingcap.com>

https://github.com/pingcap/blog/issues/695

Usage: add `/schedule 2019-12-31` at the end of the description of the target pull request, and it will be merged at 16:00 (Beijing Time) on that scheduled day.