### PR TITLE
disable the scheduled link checker

### DIFF
--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -3,8 +3,8 @@ name: Links
 on:
   repository_dispatch:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 1"
+  #schedule:
+  #  - cron: "0 0 * * 1"
 
 jobs:
   linkChecker:


### PR DESCRIPTION
Disable the scheduled link checker because the blog content is now maintained on WordPress instead of GitHub. 

The content team will use a new plugin to check broken links. 